### PR TITLE
Fix wrong path for link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ This custom component is based on [integration_blueprint template](https://githu
 It comes with development environment in a container, easy to launch
 if you use Visual Studio Code. With this container you will have a stand alone
 Home Assistant instance running and already configured with the included
-[`.devcontainer/configuration.yaml`](https://github.com/oncleben31/ha-pool_pump/blob/master/.devcontainer/configuration.yaml)
+[`.devcontainer/configuration.yaml`](./.devcontainer/configuration.yaml)
 file.
 
 ## License


### PR DESCRIPTION
For an unknown reason the link was pointing to a one of my repository.
Probably a too quick copy/paste.