### PR TITLE
retain user input after an error

### DIFF
--- a/custom_components/integration_blueprint/config_flow.py
+++ b/custom_components/integration_blueprint/config_flow.py
@@ -44,6 +44,11 @@ class BlueprintFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             return await self._show_config_form(user_input)
 
+        user_input = {}
+        # Provide defaults for form
+        user_input[CONF_USERNAME] = ""
+        user_input[CONF_PASSWORD] = ""
+
         return await self._show_config_form(user_input)
 
     @staticmethod
@@ -56,7 +61,10 @@ class BlueprintFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
-                {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
+                {
+                    vol.Required(CONF_USERNAME, default=user_input[CONF_USERNAME]): str,
+                    vol.Required(CONF_PASSWORD, default=user_input[CONF_PASSWORD]): str,
+                }
             ),
             errors=self._errors,
         )


### PR DESCRIPTION
The form blanks out the input (username and password) when the form is displayed following an error.  This leaves the user wondering what they typed wrong on the first try.

With this change it is easier on the user because they just need to correct the username or password and try again.