### PR TITLE
Fix testing by bumping pytest-homeassistant-custom-component

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,1 @@
 pytest-homeassistant-custom-component==0.3.0
-

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,2 @@
--r requirements_dev.txt
-pytest-homeassistant-custom-component==0.1.0
+pytest-homeassistant-custom-component==0.3.0
+


### PR DESCRIPTION
This bumps version to 0.3.0.  To do this, we also need to remove the `requirements_dev.txt` chaining as it seems to take precedence on homeassistant version, i.e. pytest-homeassistant-custom-component==0.3.0 will try to install homeassistant==2021.4.0b4 and requirements_dev.txt will currently install homeassistant==2021.3.4.  Developers will still have perpetual problems if they install via one requirement then the other unfortunately. 

Fixes #53