### PR TITLE
Use `enable_custom_integrations` fixture by default

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,1 +1,1 @@
-pytest-homeassistant-custom-component==0.3.0
+pytest-homeassistant-custom-component==0.4.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ pytest_plugins = "pytest_homeassistant_custom_component"
 
 
 # This fixture enables loading custom integrations in all tests.
-# Remove to enable selective uae of this fixture
+# Remove to enable selective use of this fixture
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations):
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,13 @@ import pytest
 pytest_plugins = "pytest_homeassistant_custom_component"
 
 
+# This fixture enables loading custom integrations in all tests.
+# Remove to enable selective uae of this fixture
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    yield
+
+
 # This fixture is used to prevent HomeAssistant from attempting to create and dismiss persistent
 # notifications. These calls would fail without this fixture since the persistent_notification
 # integration is never loaded during a test.


### PR DESCRIPTION
Custom integrations were supposed to use `enable_custom_integrations` fixture in tests, but there was some loop hole that caused it to not be necessary. This loop hole was closed recently, and is now required for core versions >2021.6.0b0.

This bumps `pytest-homeassistant-custom-component` which now uses 2021.6.0b0 and adds a fixture to enable this built-in fixture for each test.

Changes: https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/compare/0.3.0...0.4.0
