### PR TITLE
remove async_timeout.timeout loop arg

### DIFF
--- a/custom_components/integration_blueprint/api.py
+++ b/custom_components/integration_blueprint/api.py
@@ -38,7 +38,7 @@ class IntegrationBlueprintApiClient:
     ) -> dict:
         """Get information from the API."""
         try:
-            async with async_timeout.timeout(TIMEOUT, loop=asyncio.get_event_loop()):
+            async with async_timeout.timeout(TIMEOUT):
                 if method == "get":
                     response = await self._session.get(url, headers=headers)
                     return await response.json()


### PR DESCRIPTION
Per:

https://github.com/home-assistant/core/blob/5d0c75888650d697d45bc6a4d3a8a9e1a3fa5c66/homeassistant/async_timeout_backcompat.py#L20-L34

Handled here:

https://github.com/aio-libs/async-timeout/blob/5dcb3b76235ca6a1ebdf6d8c166a58f2606b9b75/async_timeout/__init__.py#L237-L249