### PR TITLE
remove update listener on entry unload to avoid multiple listeners

### DIFF
--- a/custom_components/integration_blueprint/__init__.py
+++ b/custom_components/integration_blueprint/__init__.py
@@ -61,7 +61,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 hass.config_entries.async_forward_entry_setup(entry, platform)
             )
 
-    entry.add_update_listener(async_reload_entry)
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     return True
 
 


### PR DESCRIPTION
This fixes the issue in #67 where updating configuration options causes errors in logs 

Documentation: https://developers.home-assistant.io/docs/config_entries_options_flow_handler/#signal-updates