### PR TITLE
Update devcontainer image to fix error 128 on rebuild

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 // See https://aka.ms/vscode-remote/devcontainer.json for format details.
 {
-	"image": "ludeeus/container:integration-debian",
+	"image": "ghcr.io/ludeeus/devcontainer/integration:latest",
 	"name": "Blueprint integration development",
 	"context": "..",
 	"appPort": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 // See https://aka.ms/vscode-remote/devcontainer.json for format details.
 {
-	"image": "ghcr.io/ludeeus/devcontainer/integration:latest",
+	"image": "ghcr.io/ludeeus/devcontainer/integration:stable",
 	"name": "Blueprint integration development",
 	"context": "..",
 	"appPort": [


### PR DESCRIPTION
This fixes an issue preventing the pulling of home assistant by updating to the latest supported image. Fixes #71.

## The problem
Currently when rebuilding the container pointing at `ludeeus/container:integration-debian` which is an old image, the boot fails with a 128 error in git.

## The solution
Updating the image to the new URL from ludeeus fixes this. The new image is Debian by default and pulls the latest Python version.